### PR TITLE
send SIGTERM to main process only

### DIFF
--- a/templates/cdnjs-bot.service
+++ b/templates/cdnjs-bot.service
@@ -3,6 +3,7 @@ Description=cdnjs autoupdate bot
 
 [Service]
 ExecStart=/usr/local/bin/autoupdate
+KillMode=mixed
 User=sven
 Group=sven
 Environment=BOT_BASE_PATH={{ bot_base_path }}


### PR DESCRIPTION
I think the [`KillMode` directive](https://www.freedesktop.org/software/systemd/man/systemd.kill.html#KillMode=) should fix our issue [here](https://github.com/cdnjs/tools/issues/97).