### PR TITLE
increase timeout from 90s -> 5min

### DIFF
--- a/templates/cdnjs-bot.service
+++ b/templates/cdnjs-bot.service
@@ -4,6 +4,7 @@ Description=cdnjs autoupdate bot
 [Service]
 ExecStart=/usr/local/bin/autoupdate
 KillMode=mixed
+TimeoutStopSec=5min
 User=sven
 Group=sven
 Environment=BOT_BASE_PATH={{ bot_base_path }}


### PR DESCRIPTION
The `DefaultTimeoutStopSec` is [`90s`](https://www.freedesktop.org/software/systemd/man/systemd-system.conf.html#)... this will increase it to `5min` by setting [`TimeoutStopSec`](https://www.freedesktop.org/software/systemd/man/systemd.service.html).

This is the time `systemd` will wait for a program to terminate after sending `SIGTERM`, after which it will send `SIGKILL`.

